### PR TITLE
Add namespaced SAF-T parser

### DIFF
--- a/saft_tripletex.py
+++ b/saft_tripletex.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# Namespace used by Tripletex SAF-T exports
+NS = {"s": "urn:StandardAuditFile-Tax"}
+
+
+def parse(path: str | Path) -> ET.Element:
+    """Parse SAF-T XML file and return root element."""
+    return ET.parse(path).getroot()
+
+
+def get_accounts(root: ET.Element) -> list[dict[str, str]]:
+    """Return a list of accounts found in the file."""
+    accounts = []
+    for acct in root.findall(".//s:GeneralLedgerAccounts/s:Account", namespaces=NS):
+        accounts.append({
+            "id": acct.findtext("s:AccountID", default="", namespaces=NS),
+            "description": acct.findtext("s:AccountDescription", default="", namespaces=NS),
+            "type": acct.findtext("s:AccountType", default="", namespaces=NS),
+        })
+    return accounts
+
+
+def get_journals(root: ET.Element) -> list[dict[str, object]]:
+    """Return a list of journals and their transactions."""
+    journals = []
+    for journal in root.findall(".//s:GeneralLedgerEntries/s:Journal", namespaces=NS):
+        transactions = []
+        for tx in journal.findall("s:Transaction", namespaces=NS):
+            transactions.append({
+                "id": tx.findtext("s:TransactionID", default="", namespaces=NS),
+                "description": tx.findtext("s:Description", default="", namespaces=NS),
+                "period": tx.findtext("s:Period", default="", namespaces=NS),
+            })
+        journals.append({
+            "id": journal.findtext("s:JournalID", default="", namespaces=NS),
+            "description": journal.findtext("s:Description", default="", namespaces=NS),
+            "transactions": transactions,
+        })
+    return journals
+
+
+def get_transactions(root: ET.Element) -> list[dict[str, str]]:
+    """Return all transactions from all journals."""
+    txs = []
+    for tx in root.findall(".//s:GeneralLedgerEntries/s:Journal/s:Transaction", namespaces=NS):
+        txs.append({
+            "id": tx.findtext("s:TransactionID", default="", namespaces=NS),
+            "description": tx.findtext("s:Description", default="", namespaces=NS),
+            "period": tx.findtext("s:Period", default="", namespaces=NS),
+        })
+    return txs
+
+
+if __name__ == "__main__":
+    import argparse
+    import pprint
+
+    parser = argparse.ArgumentParser(description="Parse Tripletex SAF-T file")
+    parser.add_argument("xml_file", type=Path)
+    args = parser.parse_args()
+
+    root = parse(args.xml_file)
+    accounts = get_accounts(root)
+    journals = get_journals(root)
+    transactions = get_transactions(root)
+
+    print(f"Accounts: {len(accounts)}")
+    print(f"Journals: {len(journals)}")
+    print(f"Transactions: {len(transactions)}")
+    pprint.pprint(accounts[:3])
+    if journals:
+        pprint.pprint(journals[0])

--- a/test_saft_tripletex.py
+++ b/test_saft_tripletex.py
@@ -1,0 +1,45 @@
+import unittest
+from saft_tripletex import get_accounts, get_journals, get_transactions, NS
+import xml.etree.ElementTree as ET
+
+SAMPLE_XML = f"""
+<AuditFile xmlns='{NS['s']}'>
+    <GeneralLedgerAccounts>
+        <Account>
+            <AccountID>1000</AccountID>
+            <AccountDescription>Bank</AccountDescription>
+            <AccountType>BS</AccountType>
+        </Account>
+    </GeneralLedgerAccounts>
+    <GeneralLedgerEntries>
+        <Journal>
+            <JournalID>1</JournalID>
+            <Description>Journal</Description>
+            <Transaction>
+                <TransactionID>10</TransactionID>
+                <Description>Desc</Description>
+                <Period>2024-01</Period>
+            </Transaction>
+        </Journal>
+    </GeneralLedgerEntries>
+</AuditFile>
+"""
+
+class TestSaftTripletex(unittest.TestCase):
+    def setUp(self):
+        self.root = ET.fromstring(SAMPLE_XML)
+
+    def test_accounts(self):
+        accounts = get_accounts(self.root)
+        self.assertEqual(accounts[0]["id"], "1000")
+        self.assertEqual(accounts[0]["description"], "Bank")
+
+    def test_journals_and_transactions(self):
+        journals = get_journals(self.root)
+        self.assertEqual(journals[0]["id"], "1")
+        self.assertEqual(journals[0]["transactions"][0]["id"], "10")
+        txs = get_transactions(self.root)
+        self.assertEqual(txs[0]["description"], "Desc")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `saft_tripletex.py` implementing parsing of Tripletex SAF‑T XML
- include namespace constant `NS` and use it in all XPath expressions
- provide unit tests confirming namespaced tags are read

## Testing
- `python -m unittest -v test_saft_tripletex.py`