### PR TITLE
Ensure regnskapslinjer columns are visible

### DIFF
--- a/src/app/gui/bilag_gui_tk.py
+++ b/src/app/gui/bilag_gui_tk.py
@@ -184,6 +184,10 @@ class App(tk.Tk):
         self._konto2regnr: dict[str, int] = self._load_regnr_map()
         self._regnr2name: dict[int, str] = {}  # fylles første gang du mapper/overstyrer
 
+        # sørg for at self.df_full også har regnr/linje-kolonner fra start slik at
+        # de dukker opp i søkemenyen og andre operasjoner som bruker self.df_full
+        self.df_full = self._with_regnskapslinjer_cols(self.df_full)
+
         df_initial = self._with_regnskapslinjer_cols(df_initial)
 
         # 5) Bygg UI


### PR DESCRIPTION
## Summary
- ensure the full dataset in the bilag GUI is decorated with regnr/regnskapslinje columns from the start so they appear in search/dropdown lists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e435b674f48332852d1ce6d70a3929